### PR TITLE
Switch to JDK for running Drill

### DIFF
--- a/apache-drill/Dockerfile
+++ b/apache-drill/Dockerfile
@@ -14,7 +14,7 @@
 FROM alpine:latest
 MAINTAINER Hari Sekhon (https://www.linkedin.com/in/harisekhon)
 
-ARG APACHE_DRILL_VERSION=1.10.0
+ARG APACHE_DRILL_VERSION=1.11.0
 
 ARG TAR=apache-drill-${APACHE_DRILL_VERSION}.tar.gz
 
@@ -35,7 +35,7 @@ WORKDIR /
 # supervisor => drillbit standalone runner for nagios checks
 # which      => drill-embedded script
 RUN set -euxo pipefail && \
-    apk add --no-cache bash openjdk8-jre-base supervisor which && \
+    apk add --no-cache bash openjdk8 supervisor which && \
     mkdir -p /etc/supervisor.d
 
 RUN set -euxo pipefail && \


### PR DESCRIPTION
Drill querying does not work when running under a JRE. It shows the error message

> Error: SYSTEM ERROR: RuntimeException: JDK Java compiler not available - probably you're running Drill with a JRE and not a JDK

The issue is described in more detail at http://www.openkb.info/2017/05/drill-errors-with-jdk-java-compiler-not.html

This PR switches the docker image to use the JDK instead. It also upgrades the container to use Drill 1.11.