### PR TITLE
Config fixes for Riak 1 and 2

### DIFF
--- a/riak/Dockerfile
+++ b/riak/Dockerfile
@@ -38,7 +38,7 @@ RUN set -euxo pipefail && \
 
 # make HTTP listen on 0.0.0.0 not 127.0.0.1
 # Riak 1.x
-COPY conf/app.config /etc/riak/
+#COPY conf/app.config /etc/riak/
 # Riak 2.x
 COPY conf/riak.conf /etc/riak/
 

--- a/riak/conf/app.config
+++ b/riak/conf/app.config
@@ -12,7 +12,7 @@
 
             %% pb is a list of IP addresses and TCP ports that the Riak
             %% Protocol Buffers interface will bind.
-            {pb, [ {"127.0.0.1", 8087 } ]}
+            {pb, [ {"0.0.0.0", 8087 } ]}
             ]},
 
  %% Riak Core config


### PR DESCRIPTION
There are two different fixes in this PR:

* configuration file for Riak 1 (`app.config`) was not binding to the correct interface, rendering the protobuf protocol inaccessible outside of the container;

* `Dockerfile` for Riak 2 copied `app.config` (version 1) together with `riak.conf` (version 2), which effectively hides the later in favor of the former (compatibility?).
