### PR TITLE
sshd-keygen no longer exists

### DIFF
--- a/hadoop/entrypoint.sh
+++ b/hadoop/entrypoint.sh
@@ -40,6 +40,12 @@ EOF
     done
 
     if ! [ -f /etc/ssh/ssh_host_rsa_key ]; then
+        ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key -C '' -N ''
+        chgrp ssh_keys /etc/ssh/ssh_host_rsa_key
+        chmod 640 /etc/ssh/ssh_host_rsa_key
+        chmod 644 /etc/ssh/ssh_host_rsa_key.pub
+    fi
+
         /usr/sbin/sshd-keygen || :
     fi
 


### PR DESCRIPTION
The base CentOS image, at some point, drifted to CentOS 8 from 7. At that moment the `sshd-keygen` script was removed,
which generates ssh keys for the various hadoop processes connecting back to the host using ssh.

Replace with direct invocation of the `ssh-keygen` command needed.
These commands were sourced from [Red Hat Bug #1325535](https://bugzilla.redhat.com/show_bug.cgi?id=1325535)