### PR TITLE
Fix two error in Hadoop entry point file.

### DIFF
--- a/hadoop/entrypoint.sh
+++ b/hadoop/entrypoint.sh
@@ -23,14 +23,15 @@ export PATH="$PATH:/hadoop/sbin:/hadoop/bin"
 if [ $# -gt 0 ]; then
     exec "$@"
 else
-    for x in root hdfs yarn; do
-        if ! [ -f "$x/.ssh/id_rsa" ]; then
+    for tuple in root,root hdfs,/home/hdfs yarn,/home/yarn; do
+        IFS=',' read x xhome <<< "${tuple}"
+        if ! [ -f "$xhome/.ssh/id_rsa" ]; then
             su - "$x" <<-EOF
                 [ -n "${DEBUG:-}" ] && set -x
                 ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
 EOF
         fi
-        if ! [ -f "$x/.ssh/authorized_keys" ]; then
+        if ! [ -f "$xhome/.ssh/authorized_keys" ]; then
             su - "$x" <<-EOF
                 [ -n "${DEBUG:-}" ] && set -x
                 cp -v ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys

--- a/hadoop/entrypoint.sh
+++ b/hadoop/entrypoint.sh
@@ -80,7 +80,7 @@ EOF
     mkdir -pv /hadoop/logs
 
     sed -i "s/localhost/$hostname/" /hadoop/etc/hadoop/core-site.xml
-
+#    rm -f /run/nologin
     start-dfs.sh
     start-yarn.sh
     tail -f /dev/null /hadoop/logs/*


### PR DESCRIPTION
- ssh id_rsa path:
It wrongly check ssh key path for hdfs and yarn user without `/home/` prefix. To solve tuple item created as `username,home_path`, in the for it iterate over tuples and username will be stored into `x` and home path into `xhome`.
- Unprivileged log in:
It seems Cent Os does not allow establish connection with unprivileged login, the error is:
```
localhost: "System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8)."
```
and it close localhost ssh connection with port 22. To solve the `rm -f /run/nologin` before starting the service.